### PR TITLE
메인 수정

### DIFF
--- a/app/src/main/java/com/diary/paintlog/view/fragments/MainFragment.kt
+++ b/app/src/main/java/com/diary/paintlog/view/fragments/MainFragment.kt
@@ -13,6 +13,8 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -60,6 +62,25 @@ class MainFragment : Fragment() {
     @SuppressLint("SetTextI18n")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        var backPressedTime: Long = 0L
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (binding.diaryView.visibility == View.VISIBLE) {
+                    getBackDiary()
+                } else {
+                    if (System.currentTimeMillis() - backPressedTime >= 2000L) {
+                        backPressedTime = System.currentTimeMillis()
+                        Toast.makeText(binding.root.context, "한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT)
+                            .show()
+                    } else {
+                        requireActivity().finish()
+                    }
+                }
+            }
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, callback)
 
         // 원하는 이미지를 리스트에 넣어서 평균 RGB값을 구함
 //        getAvgRGB()
@@ -396,7 +417,7 @@ class MainFragment : Fragment() {
             for (data in diaryViewModel.getDiaryAll()) {
                 val date = data.diary.registeredAt
                 val diaryDate = CalendarDay.from(date.year, date.monthValue, date.dayOfMonth)
-                val color = if(data.colors.isNotEmpty()){
+                val color = if (data.colors.isNotEmpty()) {
                     Common.blendColors(requireContext(), data.colors)
                 } else {
                     ContextCompat.getColor(requireContext(), R.color.gray)
@@ -437,7 +458,7 @@ class MainFragment : Fragment() {
         }
     }
 
-    private fun getAvgRGB(){
+    private fun getAvgRGB() {
         val drawableList = listOf(
             R.drawable.drawing_01_01,
             R.drawable.drawing_01_02,
@@ -503,7 +524,7 @@ class MainFragment : Fragment() {
             R.drawable.drawing_10_09,
         )
 
-        for(drawableId in drawableList){
+        for (drawableId in drawableList) {
             val drawable = ContextCompat.getDrawable(requireContext(), drawableId)
             val bitmap = (drawable as BitmapDrawable).bitmap
             Palette.from(bitmap).generate { palette ->
@@ -530,7 +551,7 @@ class MainFragment : Fragment() {
                     val avgG = g / totalPopulation
                     val avgB = b / totalPopulation
 
-                    val color = Color.rgb(avgR.toInt(),avgG.toInt(),avgB.toInt())
+                    val color = Color.rgb(avgR.toInt(), avgG.toInt(), avgB.toInt())
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -20,6 +20,7 @@
         android:id="@+id/diary_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:visibility="invisible"
         app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
1. 일기 상세보기에서 뒤로가기 하는 경우 상세보기 닫게 수정 (기존 바로 어플 종료)
2. 메인에서 뒤로가기 2번 눌려 앱 종료하도록 추가 (기존 뒤로가기 한번에 바로 종료)