### PR TITLE
백그라운드 위치 정보 사용권한 제거

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,7 @@ android {
         applicationId = "com.diary.paintlog"
         minSdk = 26
         targetSdk = 34
-        versionCode = 4
+        versionCode = 8
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
     <!-- 위치 정보 사용 권한 설정 -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
 
     <application
         android:name=".GlobalApplication"


### PR DESCRIPTION
작업사항
- 백그라운드 위치 정보 사용권한 제거

구글 플레이 앱 등록시 백그라운드 위치 정보 사용 권한이 문제를 발생해 제거함.